### PR TITLE
Ensure that there are not Agent* Attributes left in converted Resource

### DIFF
--- a/src/main/java/org/cip4/jdflib/extensions/xjdfwalker/jdftoxjdf/WalkResource.java
+++ b/src/main/java/org/cip4/jdflib/extensions/xjdfwalker/jdftoxjdf/WalkResource.java
@@ -176,6 +176,8 @@ public class WalkResource extends WalkJDFElement
 		newResLeaf.removeAttribute(AttributeName.LOCKED);
 		newResLeaf.removeAttribute(AttributeName.SPAWNIDS);
 		newResLeaf.removeAttribute(AttributeName.SPAWNSTATUS);
+		newResLeaf.removeAttribute(AttributeName.AGENTNAME);
+		newResLeaf.removeAttribute(AttributeName.AGENTVERSION);
 	}
 
 	/**

--- a/src/test/java/org/cip4/jdflib/extensions/xjdfwalker/JDFToXJDFConverterTest.java
+++ b/src/test/java/org/cip4/jdflib/extensions/xjdfwalker/JDFToXJDFConverterTest.java
@@ -2977,6 +2977,21 @@ public class JDFToXJDFConverterTest extends JDFTestCaseBase
 		h.writeToFile(sm_dirTestDataTemp + "prepress.xjdf");
 	}
 
+	@Test
+	public void testRemoveAgentFromResource()
+	{
+		final JDFNode n = new JDFDoc(ElementName.JDF).getJDFRoot();
+
+		JDFResource runList = n.addResource(ElementName.RUNLIST, EnumUsage.Input);
+		runList.setAttribute(AttributeName.NPAGE, "4");
+		runList.setAgentName("resource agent name");
+
+		final JDFToXJDF conv = new JDFToXJDF();
+		final KElement xjdf = conv.convert(n);
+
+		assertNull(xjdf.getXPathAttribute("//ResourceSet[@Name=RunList]/Resource/@AgentName", null));
+	}
+
 	/**
 	 *
 	 * @see org.cip4.jdflib.JDFTestCaseBase#tearDown()


### PR DESCRIPTION
Ensure that there are not Agent* Attributes left in when converting Resource from JDF to XJDF

Issues: JDFLIB-10